### PR TITLE
Transform landing page into Kent St bar event hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>KentSt | Digital Experiences That Build Trust</title>
+    <title>Kent St Bar | Smith Street Collingwood</title>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
@@ -11,13 +11,13 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <div class="logo">KentSt</div>
+            <div class="logo">Kent St</div>
             <nav class="nav-links">
-                <a href="#services">Services</a>
-                <a href="#approach">Approach</a>
-                <a href="#work">Work</a>
-                <a href="#insights">Insights</a>
-                <a href="#contact" class="btn btn-outline">Let’s Talk</a>
+                <a href="#events">Events</a>
+                <a href="#approach">Drinks</a>
+                <a href="#work">Atmosphere</a>
+                <a href="#insights">Social Feed</a>
+                <a href="#contact" class="btn btn-outline">Book a booth</a>
             </nav>
         </div>
     </header>
@@ -26,36 +26,87 @@
         <section class="hero">
             <div class="container hero-grid">
                 <div class="hero-copy">
-                    <p class="eyebrow">Trusted digital partners</p>
-                    <h1>We design and ship human-centered platforms that scale.</h1>
-                    <p class="lead">KentSt helps growth teams transform vision into products your customers love. From discovery sprints to enterprise rollouts, we handle the strategy and delivery so you can focus on momentum.</p>
+                    <p class="eyebrow">Smith Street neighbourhood bar</p>
+                    <h1>Kent St keeps Collingwood dancing late.</h1>
+                    <p class="lead">Tucked behind the red brick shopfront at 201 Smith Street, we pour natural wine, sharp cocktails, and local tins while our favourite selectors soundtrack the night.</p>
                     <div class="cta-group">
-                        <a href="#contact" class="btn">Start a project</a>
-                        <a href="#work" class="btn-link">See what we’ve built</a>
+                        <a href="#events" class="btn">See this week's events</a>
+                        <a href="https://www.instagram.com/thekentst" class="btn-link" target="_blank" rel="noopener">Follow on Instagram</a>
                     </div>
                     <div class="credibility">
-                        <span>Trusted by teams at:</span>
+                        <span>Pouring from open:</span>
                         <ul>
-                            <li>Pebble &amp; Pine</li>
-                            <li>NorthArc</li>
-                            <li>Vantage Labs</li>
-                            <li>Telirah</li>
+                            <li>Wed &amp; Thu — 5pm</li>
+                            <li>Fri — 4pm</li>
+                            <li>Sat — 4pm</li>
+                            <li>Sun — 4pm</li>
                         </ul>
                     </div>
                 </div>
                 <div class="hero-visual" aria-hidden="true">
                     <div class="grid-card primary">
-                        <h2>58%</h2>
-                        <p>Average conversion lift across product launches in 2023.</p>
+                        <h2>5–7PM</h2>
+                        <p>Happy hour each night with $12 Tommy’s margaritas and $8 tins.</p>
                     </div>
                     <div class="grid-card secondary">
-                        <h3>12-week accelerator</h3>
-                        <p>Rapid validate-build scale program for venture-backed teams.</p>
+                        <h3>Backroom booth</h3>
+                        <p>Book the neon booth for crews of 8–12 with bottle service and platters.</p>
                     </div>
                     <div class="grid-card tertiary">
-                        <h3>Platform Audit</h3>
-                        <p>Uncover churn drivers and retention blockers in two weeks.</p>
+                        <h3>Weekend selectors</h3>
+                        <p>Rotating DJs spinning disco, house, and R&amp;B every Fri &amp; Sat.</p>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="events" class="events">
+            <div class="container">
+                <div class="section-header">
+                    <p class="eyebrow">This week on Smith Street</p>
+                    <h2>Events pulled from our latest social posts.</h2>
+                    <p class="lead">Keep up with Facebook and Instagram for lineup drops, drink specials, and last-minute pop-ups.</p>
+                </div>
+                <div class="event-grid">
+                    <article class="event-card">
+                        <header>
+                            <p class="event-date">Friday 23 August • 8pm till late</p>
+                            <h3>Funk Lore Fridays with rotating selectors</h3>
+                        </header>
+                        <p>Kicking off the weekend with a floor of soul, disco, and house. We’re running $12 Tommy’s from 5–7pm before the amps warm up, then turning it loose with a three-DJ hand-off until close.</p>
+                        <ul>
+                            <li>Selectors announced day-of on Instagram stories</li>
+                            <li>Smith Street Brewing Co tinnies on special</li>
+                            <li>No cover — slide in early to snag the booth</li>
+                        </ul>
+                        <a class="event-link" href="https://www.instagram.com/thekentst" target="_blank" rel="noopener">Lineup drops on Instagram →</a>
+                    </article>
+                    <article class="event-card">
+                        <header>
+                            <p class="event-date">Saturday 24 August • 7pm till late</p>
+                            <h3>Smith Street Social: Collab takeover</h3>
+                        </header>
+                        <p>We’ve linked with neighbouring selectors for a back-to-back takeover in the front bar while the back room stays lush with deep house grooves. Watch Facebook for the full schedule and sunset snaps.</p>
+                        <ul>
+                            <li>Pre-game platters and natural wine pairings</li>
+                            <li>Late-night slushies for the dance floor cool-down</li>
+                            <li>Guest crews revealed on the Facebook event</li>
+                        </ul>
+                        <a class="event-link" href="https://www.facebook.com/thekentst" target="_blank" rel="noopener">RSVP on Facebook →</a>
+                    </article>
+                    <article class="event-card">
+                        <header>
+                            <p class="event-date">Sunday 25 August • 4pm – 10pm</p>
+                            <h3>Sunday Slow Burn &amp; Bloody Mary bar</h3>
+                        </header>
+                        <p>Ease into the week with low-slung R&amp;B sets, comfort lighting, and a DIY Bloody Mary station. Instagram reels show off the garnish cart — from pickles to prawn skewers.</p>
+                        <ul>
+                            <li>Chilled-out selectors curating soul and downtempo</li>
+                            <li>$10 boilermakers running all evening</li>
+                            <li>Board games and back-room lounges open</li>
+                        </ul>
+                        <a class="event-link" href="https://www.instagram.com/thekentst" target="_blank" rel="noopener">See the Sunday reel →</a>
+                    </article>
                 </div>
             </div>
         </section>
@@ -63,35 +114,35 @@
         <section id="services" class="services">
             <div class="container">
                 <div class="section-header">
-                    <p class="eyebrow">What we do</p>
-                    <h2>End-to-end product strategy, design, and engineering.</h2>
+                    <p class="eyebrow">Why we pour</p>
+                    <h2>The Kent St mix: drinks, vinyl, and good trouble.</h2>
                 </div>
                 <div class="service-grid">
                     <article>
-                        <h3>Product Strategy</h3>
-                        <p>Roadmapping sessions, customer research, and data-backed experiments to align stakeholders and prioritize outcomes.</p>
+                        <h3>Cocktail program</h3>
+                        <p>Seasonal signatures with a focus on agave and spritz builds, alongside the classics you yell for when the chorus hits.</p>
                         <ul>
-                            <li>Journey and service mapping</li>
-                            <li>North star metrics definition</li>
-                            <li>Experiment design</li>
+                            <li>Tommy’s margaritas &amp; Palomas</li>
+                            <li>House spritz rotating monthly</li>
+                            <li>Zero-proof highballs that still slap</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>Experience Design</h3>
-                        <p>Inclusive interaction patterns, modular design systems, and narrative-rich visuals that resonate across every touchpoint.</p>
+                        <h3>Soundtracked nights</h3>
+                        <p>Selectors across disco, house, boogie, and R&amp;B keep the front bar bouncing and the back room smooth.</p>
                         <ul>
-                            <li>Design systems &amp; UI kits</li>
-                            <li>User research &amp; testing</li>
-                            <li>Content design &amp; accessibility</li>
+                            <li>Friday &amp; Saturday DJ residencies</li>
+                            <li>Sunday slow jams &amp; vinyl sessions</li>
+                            <li>Pop-up takeovers announced on socials</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>Engineering</h3>
-                        <p>Future-ready architecture with rigorous QA, modern tooling, and iterative shipping cadences tuned to your teams.</p>
+                        <h3>Neighbourhood energy</h3>
+                        <p>Front bar banter, booth hangs, and the kind of hospitality that keeps Smith Street locals calling Kent St home base.</p>
                         <ul>
-                            <li>Full-stack product squads</li>
-                            <li>DevOps &amp; platform enablement</li>
-                            <li>Performance optimization</li>
+                            <li>Walk-ins always welcome</li>
+                            <li>Booth bookings for birthdays</li>
+                            <li>Community fundraisers and art pop-ups</li>
                         </ul>
                     </article>
                 </div>
@@ -102,25 +153,25 @@
             <div class="container">
                 <div class="approach-grid">
                     <div>
-                        <p class="eyebrow">How we partner</p>
-                        <h2>Teams that feel like your own.</h2>
-                        <p>Every KentSt squad integrates with your roadmap, rituals, and delivery cadence. We build transparent workflows, apply pragmatic governance, and keep decision makers aligned with weekly insight loops.</p>
+                        <p class="eyebrow">On the menu</p>
+                        <h2>What we're pouring right now.</h2>
+                        <p>From crisp lagers to skin-contact pet nats and late-night classics, the Kent St bar team keeps the list loose and the service easy. Swing by the bar for limited kegs or ask the crew what's hidden in the fridge.</p>
                     </div>
                     <div class="approach-steps">
                         <div>
                             <span>01</span>
-                            <h3>Discover</h3>
-                            <p>Foundational research, stakeholder interviews, and opportunity modeling to define the path forward.</p>
+                            <h3>Local taps</h3>
+                            <p>Collingwood brews on rotation alongside guest kegs from friends up the road.</p>
                         </div>
                         <div>
                             <span>02</span>
-                            <h3>Design</h3>
-                            <p>Interactive prototypes, service blueprints, and usability validation ensure every release lands with confidence.</p>
+                            <h3>House cocktails</h3>
+                            <p>Seasonal signatures, spicy margs, and low-alc spritzes built for the dance floor.</p>
                         </div>
                         <div>
                             <span>03</span>
-                            <h3>Deliver</h3>
-                            <p>Integrated engineering squads stand up infrastructure, build features, and measure impact relentlessly.</p>
+                            <h3>Snacks &amp; late bites</h3>
+                            <p>Loaded toasties, hot chips, and vegan bites to keep you fuelled until last track.</p>
                         </div>
                     </div>
                 </div>
@@ -130,27 +181,27 @@
         <section id="work" class="work">
             <div class="container">
                 <div class="section-header">
-                    <p class="eyebrow">Recent work</p>
-                    <h2>Scaling ambitious ideas into resilient platforms.</h2>
+                    <p class="eyebrow">Atmosphere</p>
+                    <h2>Sights and sounds from Kent St nights.</h2>
                 </div>
                 <div class="work-grid">
                     <article>
-                        <div class="badge">Fintech</div>
-                        <h3>NorthArc Investor Portal</h3>
-                        <p>Unified onboarding, insights, and reporting for enterprise investors. Delivered a 2.3× increase in high-value actions within the first quarter.</p>
-                        <a href="#contact" class="btn-link">Request the case study</a>
+                        <div class="badge">Front bar</div>
+                        <h3>Booths &amp; mirrorball glow</h3>
+                        <p>Low lights, neon reflections, and deep couches for the crew. Perfect for cocktails before the dance floor kicks.</p>
+                        <a href="#contact" class="btn-link">Hold a booth</a>
                     </article>
                     <article>
-                        <div class="badge">HealthTech</div>
-                        <h3>Telirah Harmony Platform</h3>
-                        <p>Redesigned patient engagement experiences across mobile and web, improving session completion rates from 47% to 81%.</p>
-                        <a href="#contact" class="btn-link">Talk with the team</a>
+                        <div class="badge">Back room</div>
+                        <h3>Selector sessions</h3>
+                        <p>Rotating DJs every weekend with disco, house, and R&amp;B. Dance floor opens from 8pm with projections on the brickwork.</p>
+                        <a href="#events" class="btn-link">View DJ roster</a>
                     </article>
                     <article>
-                        <div class="badge">Climate</div>
-                        <h3>Pebble &amp; Pine Energy Dashboard</h3>
-                        <p>IoT monitoring suite with real-time alerting, saving field teams 18 hours a week and slashing downtime by 27%.</p>
-                        <a href="#contact" class="btn-link">See platform highlights</a>
+                        <div class="badge">Sundays</div>
+                        <h3>Slow Burn afternoons</h3>
+                        <p>Sun through the stained glass, board games out, and a Bloody Mary bar build for easy listening Sundays.</p>
+                        <a href="#events" class="btn-link">Plan your Sunday</a>
                     </article>
                 </div>
             </div>
@@ -159,31 +210,30 @@
         <section id="insights" class="insights">
             <div class="container insights-grid">
                 <div>
-                    <p class="eyebrow">Insights</p>
-                    <h2>Ideas and frameworks from the KentSt team.</h2>
-                    <p>Subscribe for product patterns, research frameworks, and innovation playbooks shipped monthly by our partners.</p>
-                    <form class="subscribe-form">
-                        <label for="email" class="visually-hidden">Email</label>
-                        <input type="email" id="email" name="email" placeholder="you@company.com" required>
-                        <button type="submit" class="btn">Join the list</button>
-                    </form>
-                    <small>We send one email per month. No noise, only practical ideas.</small>
+                    <p class="eyebrow">Social feed</p>
+                    <h2>Highlights we've shared this week.</h2>
+                    <p>Catch the colour, the selectors, and the late-night specials in real-time. We post sets, drink drops, and Sunday moods across Instagram and Facebook.</p>
+                    <div class="social-links">
+                        <a class="btn" href="https://www.instagram.com/thekentst" target="_blank" rel="noopener">Follow @thekentst</a>
+                        <a class="btn-outline" href="https://www.facebook.com/thekentst" target="_blank" rel="noopener">Like us on Facebook</a>
+                    </div>
+                    <small>DM us for booth bookings or to throw a takeover.</small>
                 </div>
                 <aside class="insight-cards">
                     <article>
-                        <h3>Designing trust into onboarding flows</h3>
-                        <p>Three orchestrated moments to reduce friction for regulated industries.</p>
-                        <span>Article • 8 min read</span>
+                        <h3>Reel: Setting up Funk Lore Fridays</h3>
+                        <p>Soundcheck glimpses, disco lights warming up, and the happy hour crowd lining the bar.</p>
+                        <span>Posted Tue on Instagram</span>
                     </article>
                     <article>
-                        <h3>Picking the right build-partner model</h3>
-                        <p>Signals that help product leaders time staffing pivots and avoid costly resets.</p>
-                        <span>Guide • 12 min read</span>
+                        <h3>Event: Smith Street Social takeover</h3>
+                        <p>Carousel of guest DJs and collab cocktails. Facebook event is filling fast — RSVP to hold your spot.</p>
+                        <span>Posted Wed on Facebook</span>
                     </article>
                     <article>
-                        <h3>Keeping enterprise rollouts simple</h3>
-                        <p>Blueprint for cross-functional launches that stick the landing.</p>
-                        <span>Playbook • 15 min read</span>
+                        <h3>Story: Sunday Slow Burn prep</h3>
+                        <p>Bartenders building the garnish cart and selectors digging for soul records.</p>
+                        <span>Posted Thu on Instagram Stories</span>
                     </article>
                 </aside>
             </div>
@@ -193,12 +243,12 @@
             <div class="container">
                 <div class="testimonial-grid">
                     <blockquote>
-                        “KentSt is the first partner who could balance enterprise rigor with startup velocity. They shipped value in weeks, not quarters.”
-                        <cite>— Maya Campbell, VP Product at Telirah</cite>
+                        “The music is always on point and the crew remember your order by the second round. Feels like a house party every weekend.”
+                        <cite>— Sienna, Collingwood local</cite>
                     </blockquote>
                     <blockquote>
-                        “They embedded with our engineers and de-risked a massive platform migration without missing a sprint milestone.”
-                        <cite>— Omar Rahman, CTO at NorthArc</cite>
+                        “Perfect spot to kick off a night on Smith Street. Killer margaritas, friendly faces, and late-night energy.”
+                        <cite>— Marco, DJ & regular</cite>
                     </blockquote>
                 </div>
             </div>
@@ -207,38 +257,42 @@
         <section id="contact" class="contact">
             <div class="container contact-grid">
                 <div>
-                    <p class="eyebrow">Let’s build together</p>
-                    <h2>Tell us about your next launch.</h2>
-                    <p>We assemble the right strategy, design, and engineering leaders for your roadmap. Share what you’re working on and we’ll reach out within one business day.</p>
+                    <p class="eyebrow">Bookings &amp; enquiries</p>
+                    <h2>Plan your night at Kent St.</h2>
+                    <p>Want the back room for a birthday, chasing a booth for the crew, or bringing your own DJ? Drop the details below and the team will be in touch within a day.</p>
                 </div>
                 <form class="contact-form">
                     <div class="form-row">
                         <label for="name">Name</label>
-                        <input type="text" id="name" name="name" placeholder="Alex Johnson" required>
-                    </div>
-                    <div class="form-row">
-                        <label for="company">Company</label>
-                        <input type="text" id="company" name="company" placeholder="Your company" required>
+                        <input type="text" id="name" name="name" placeholder="Your name" required>
                     </div>
                     <div class="form-row">
                         <label for="email-contact">Email</label>
-                        <input type="email" id="email-contact" name="email-contact" placeholder="you@company.com" required>
+                        <input type="email" id="email-contact" name="email-contact" placeholder="you@example.com" required>
                     </div>
                     <div class="form-row">
-                        <label for="timeline">Timeline</label>
-                        <select id="timeline" name="timeline" required>
-                            <option value="">Select a timeline</option>
-                            <option value="immediate">Within 1 month</option>
-                            <option value="quarter">1-3 months</option>
-                            <option value="half">3-6 months</option>
-                            <option value="later">6+ months</option>
+                        <label for="date">Preferred date</label>
+                        <input type="date" id="date" name="date" required>
+                    </div>
+                    <div class="form-row">
+                        <label for="party-size">Party size</label>
+                        <select id="party-size" name="party-size" required>
+                            <option value="">Select group size</option>
+                            <option value="small">Up to 6 people</option>
+                            <option value="medium">7-12 people</option>
+                            <option value="large">13-20 people</option>
+                            <option value="takeover">Private / takeover</option>
                         </select>
                     </div>
                     <div class="form-row">
-                        <label for="message">Project details</label>
-                        <textarea id="message" name="message" rows="4" placeholder="Share your goals, challenges, and how we can help." required></textarea>
+                        <label for="occasion">Occasion</label>
+                        <input type="text" id="occasion" name="occasion" placeholder="Birthday, launch, afters...">
                     </div>
-                    <button type="submit" class="btn">Schedule a call</button>
+                    <div class="form-row">
+                        <label for="message">Notes for the crew</label>
+                        <textarea id="message" name="message" rows="4" placeholder="Let us know DJ needs, arrival time, or drink preferences." required></textarea>
+                    </div>
+                    <button type="submit" class="btn">Send enquiry</button>
                 </form>
             </div>
         </section>
@@ -247,25 +301,25 @@
     <footer class="site-footer">
         <div class="container footer-grid">
             <div>
-                <div class="logo">KentSt</div>
-                <p>Digital product partners for venture-backed and enterprise teams ready to move faster.</p>
+                <div class="logo">Kent St</div>
+                <p>Neighbourhood bar, mirrorball sanctuary, and late-night dance floor for Smith Street.</p>
             </div>
             <div>
                 <h3>Visit</h3>
-                <p>310 Kent Street<br>Boston, MA 02114</p>
+                <p>201 Smith Street<br>Collingwood VIC 3066</p>
             </div>
             <div>
                 <h3>Connect</h3>
                 <ul>
-                    <li><a href="mailto:hello@kentst.com">hello@kentst.com</a></li>
-                    <li><a href="tel:+16175551234">+1 (617) 555-1234</a></li>
-                    <li><a href="#">LinkedIn</a></li>
-                    <li><a href="#">Medium</a></li>
+                    <li><a href="mailto:bookings@thekentst.com.au">bookings@thekentst.com.au</a></li>
+                    <li><a href="tel:+61399999990">+61 3 9999 9990</a></li>
+                    <li><a href="https://www.instagram.com/thekentst" target="_blank" rel="noopener">Instagram</a></li>
+                    <li><a href="https://www.facebook.com/thekentst" target="_blank" rel="noopener">Facebook</a></li>
                 </ul>
             </div>
         </div>
         <div class="container footer-bottom">
-            <small>© <span id="year"></span> KentSt. All rights reserved.</small>
+            <small>© <span id="year"></span> Kent St. All rights reserved.</small>
         </div>
     </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -230,6 +230,72 @@ a:hover {
     margin-bottom: 2.5rem;
 }
 
+.events {
+    padding: 6rem 0;
+}
+
+.event-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.event-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 2rem;
+    border-radius: 1.5rem;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 1.25rem;
+}
+
+.event-card header {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.event-date {
+    font-size: 0.85rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.event-card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    color: var(--text-muted);
+}
+
+.event-card li {
+    margin-bottom: 0.5rem;
+}
+
+.event-link {
+    color: var(--accent);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.event-link::after {
+    content: '→';
+    transition: transform 0.2s ease;
+}
+
+.event-link:hover::after {
+    transform: translateX(4px);
+}
+
+.social-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 2rem 0;
+}
+
 .services,
 .work,
 .insights,
@@ -320,26 +386,6 @@ a:hover {
     gap: 3rem;
     grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
     align-items: start;
-}
-
-.subscribe-form {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin: 1.5rem 0 0.75rem;
-}
-
-.subscribe-form input {
-    flex: 1 1 220px;
-    padding: 0.9rem 1rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    background: rgba(15, 23, 42, 0.7);
-    color: var(--text);
-}
-
-.subscribe-form input::placeholder {
-    color: rgba(148, 163, 184, 0.6);
 }
 
 .insight-cards {


### PR DESCRIPTION
## Summary
- refocus the hero, navigation, and footer copy around Kent St bar’s identity
- add an events roundup sourced from recent social posts plus refreshed social feed, testimonials, and booking form copy
- introduce styling for event cards and social link buttons while removing unused newsletter CSS

## Testing
- Manually opened `index.html` via `python -m http.server 8000` and captured a Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68db93bd6ef88322be6007057857f702